### PR TITLE
Extend middleware support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v1.0.4] - 2025-02-12
+
+### Added
+- Add `createHandler()` for easier handler authoring
+- Add support for middleware transforming response bodies (via `TransformStream`)
+- Add support for request timeout in server config
+- Add support for `--open` for more platforms
+- Add `searchParams` to `context` passed to handlers
+- Add support for inline function support instead of only module imports in handling requests
+- Significantly expands testing
+
+### Fixed
+- Pass `signal` into `HTTPResponse` body parser
+
 ## [v1.0.3] - 2025-02-08
 
 ### Added

--- a/api/favicon.js
+++ b/api/favicon.js
@@ -1,7 +1,17 @@
-export default async () => {
-	return new Response(`<svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg" width="16" height="16">
-		<rect x="0" y="0" rx="1" ry="1" width="10" height="10" fill="#${crypto.getRandomValues(new Uint8Array(3)).toHex()}"></rect>
-	</svg>`, {
-		headers: { 'Content-Type': 'image/svg+xml' },
-	});
-};
+import { createHandler } from '../handler.js';
+import { HTTPError } from '../HTTPError.js';
+
+const favicon = new Blob([`<svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg" width="16" height="16">
+	<rect x="0" y="0" rx="1" ry="1" width="10" height="10" fill="#${crypto.getRandomValues(new Uint8Array(3)).toHex()}"></rect>
+</svg>`], { type: 'image/svg+xml' });
+
+export default createHandler({
+	get(req) {
+		console.log(req.destination);
+		if (req.destination === 'image') {
+			return new Response(favicon);
+		} else {
+			throw new HTTPError('Not a valid image request', { status: 400 });
+		}
+	}
+});

--- a/api/tasks.js
+++ b/api/tasks.js
@@ -1,92 +1,73 @@
 // In-memory storage for demo
+import { createHandler } from '../handler.js';
+import { HTTPError } from '../HTTPError.js';
+
 const tasks = new Map();
 
-export default async function(req) {
-	try {
-		switch (req.method) {
-			case 'GET': {
-				const url = new URL(req.url);
+export default createHandler({
+	get(req, { searchParams }) {
+		if (searchParams.has('id')) {
+			const task = tasks.get(searchParams.get('id'));
 
-				if (url.searchParams.has('id')) {
-					const task = tasks.get(url.searchParams.get('id'));
-
-					if (typeof task?.title !== 'string') {
-						return new Response('Task not found', { status: 404 });
-					} else {
-						return Response.json(task);
-					}
-				} else {
-					return Response.json(Array.from(tasks.values()));
-				}
+			if (typeof task?.title !== 'string') {
+				throw new HTTPError('Task not found.', { status: 404 });
+			} else {
+				return Response.json(task);
 			}
-
-			case 'POST': {
-				const task = await req.json();
-
-				if (typeof task.title !== 'string') {
-					return new Response('Title is required', { status: 400 });
-				} else {
-					const newTask = {
-						id: crypto.randomUUID(),
-						title: task.title.trim(),
-						description: task.description?.trim() ?? '',
-						created: new Date().toISOString(),
-						completed: false
-					};
-
-					tasks.set(newTask.id, newTask);
-
-					return Response.json(newTask, {
-						status: 201,
-						headers: { 'Location': `/tasks?id=${newTask.id}` }
-					});
-				}
-			}
-
-			case 'PATCH': {
-				const url = new URL(req.url);
-				const id = url.searchParams.get('id');
-
-				if (! (typeof id === 'string' && tasks.has(id))) {
-					return new Response('Task not found', { status: 404 });
-				} else {
-					const updates = await req.json();
-					const task = tasks.get(id);
-					const updatedTask = {
-						...task,
-						...updates,
-						id, // Prevent ID modification
-						modified: new Date().toISOString()
-					};
-
-					tasks.set(id, updatedTask);
-
-					return Response.json(updatedTask);
-				}
-
-			}
-
-			case 'DELETE': {
-				const url = new URL(req.url);
-				const id = url.searchParams.get('id');
-
-				if (! (typeof id === 'string' && tasks.has(id))) {
-					return new Response('Task not found', { status: 404 });
-				} else {
-					tasks.delete(id);
-					return new Response(null, { status: 204 });
-				}
-			}
-
-			default:
-				return new Response('Method not allowed', {
-					status: 405,
-					headers: {
-						'Allow': 'GET, POST, PATCH, DELETE'
-					}
-				});
+		} else {
+			return Response.json(Array.from(tasks.values()));
 		}
-	} catch (error) {
-		return new Response(error.message, { status: 500 });
+	},
+	async post(req) {
+		const task = await req.json();
+
+		if (typeof task.title !== 'string') {
+			throw new HTTPError('Task is missing required fields.', { status: 400 });
+		} else {
+			const newTask = {
+				id: crypto.randomUUID(),
+				title: task.title.trim(),
+				description: task.description?.trim() ?? '',
+				created: new Date().toISOString(),
+				completed: false
+			};
+
+			tasks.set(newTask.id, newTask);
+
+			return Response.json(newTask, {
+				status: 201,
+				headers: { 'Location': new URL(`/tasks?id=${newTask.id}`, req.url) },
+			});
+		}
+	},
+	async patch(req, { searchParams }) {
+		const id = searchParams.get('id');
+
+		if (! (typeof id === 'string' && tasks.has(id))) {
+			throw new HTTPError('Task not found.', { status: 404 });
+		} else {
+			const updates = await req.json();
+			const task = tasks.get(id);
+			const updatedTask = {
+				...task,
+				...updates,
+				id, // Prevent ID modification
+				modified: new Date().toISOString()
+			};
+
+			tasks.set(id, updatedTask);
+
+			return Response.json(updatedTask);
+		}
+	},
+	delete(req, { searchParams }) {
+		const id = searchParams.get('id');
+
+		if (! (typeof id === 'string' && tasks.has(id))) {
+			throw new HTTPError('Task not found.', { status: 404 });
+		} else {
+			tasks.delete(id);
+			return new Response(null, { status: 204 });
+		}
 	}
-}
+});

--- a/cli.js
+++ b/cli.js
@@ -37,7 +37,7 @@ async function getConfig() {
 		pathname: getArg(['-a', '--path'], '/'),
 		open: hasArg(['-o', '--open']),
 		staticRoot: getArg(['-s', '--static'], '/'),
-		signal: hasArg(['-t', '--timeout']) ? AbortSignal.timeout(parseInt(getArg(['-t', '--timeout'], '0')) || 0) : undefined,
+		timeout: hasArg(['-t', '--timeout']) ? parseInt(getArg(['-t', '--timeout'], '0')) || 0 : undefined,
 		logger: hasArg(['-d', '--debug']) ? console.error : null,
 	};
 }

--- a/compression.js
+++ b/compression.js
@@ -1,0 +1,19 @@
+export function useCompression(format = 'deflate') {
+	return function(response, { request }) {
+
+		if (
+			response instanceof Response
+			&& ! response.headers.has('Content-Encoding')
+			&& response.headers.get('Content-Type').startsWith('text/')
+			&& request.headers.has('Accept-Encoding')
+			&& request.headers.get('Accept-Encoding').split(',').some(encoding => encoding.trim() === format)
+		) {
+			response.headers.set('Content-Encoding', format);
+			return new CompressionStream(format);
+		}
+	};
+}
+
+export const useGzip = useCompression('gzip');
+export const useDeflate = useCompression('deflate');
+export default useCompression;

--- a/cors.js
+++ b/cors.js
@@ -13,6 +13,10 @@ export function useCORS({ allowCredentials = false } = {}) {
 			} else {
 				response.headers.set('Access-Control-Allow-Origin', '*');
 			}
+
+			if (response.headers.has('Allow') && ! response.headers.has('Access-Control-Allow-Methods')) {
+				response.headers.set('Access-Control-Allow-Methods', response.headers.get('Allow'));
+			}
 		}
 	};
 }

--- a/handler.js
+++ b/handler.js
@@ -1,0 +1,42 @@
+import { HTTPError } from './HTTPError.js';
+
+/**
+ * Creates an HTTP request handler to handle various HTTP methods.
+ *
+ * @param {Object.<string, (req: Request, context: object) => Response | Promise<Response>} handlers HTTP method handlers (e.g., { get: fn }).
+ * @returns {(req: Request, context: object) => Promise<Response>}} HTTP request handler function.
+ * @throws {TypeError} If handlers is empty.
+ */
+export function createHandler(handlers) {
+	const methods = typeof handlers === 'object' ? Object.keys(handlers).map(method => method.toUpperCase()) : [];
+
+	if (methods.length === 0) {
+		throw new TypeError('Missing list of HTTP methods and handlers.');
+	} else {
+		/**
+		 * @param {Request} request
+		 * @param {object} context
+		 * @returns {Promise<Response>}
+		 * @throws {HTTPError}
+		 */
+		return async function(request, context) {
+			try {
+				if (handlers[request.method.toLowerCase()] instanceof Function) {
+					return await handlers[request.method.toLowerCase()](request, context);
+				} else {
+					return new Response(null, {
+						status: 405,
+						statusText: 'Method Not Allowed',
+						headers: { Allow: methods.join(', ') }
+					});
+				}
+			} catch(err) {
+				if (err instanceof HTTPError) {
+					throw err;
+				} else {
+					throw new HTTPError('An unknown error occured.', { cause: err });
+				}
+			}
+		};
+	}
+}

--- a/http-server.js
+++ b/http-server.js
@@ -1,4 +1,5 @@
 import '@shgysk8zer0/polyfills'; // Adds polyfills for eg `Promise.try()`, `URLPattern`, `URL.parse` and `URL.canParse`, etc... All new APIs in JS.
+export { createHandler } from './handler.js';
 export { serve } from './server.js';
 export { Cookie } from './Cookie.js';
 export { HTTPError } from './HTTPError.js';

--- a/http.config.js
+++ b/http.config.js
@@ -3,6 +3,10 @@ import { useCSP } from '@shgysk8zer0/http-server/csp.js';
 import { useCORS } from '@shgysk8zer0/http-server/cors.js';
 import { checkCacheItem, setCacheItem } from '@shgysk8zer0/http-server/cache.js';
 import { useRequestId } from './req-id.js';
+import { useCompression } from './compression.js';
+import { HTTPError } from './HTTPError.js';
+
+const visits = new Map();
 
 export default {
 	staticRoot: '/static/',
@@ -15,11 +19,47 @@ export default {
 		'/server': '@shgysk8zer0/http-server/api/server.js',
 		'/redirect': '@shgysk8zer0/http-server/api/redirect.js',
 		'/cache': '@shgysk8zer0/http-server/api/cache.js',
+		'/posts/:year(20\\d{2})/:month(0?\\d|[0-2])/:day(0?[1-9]|[12]\\d|3[01])/:post([a-z0-9\\-]+[a-z0-9])': (req, { matches }) => Response.json(matches),
+		'/foo/:path([A-Za-z0-9]+)': (req, {
+			matches: {
+				pathname: {
+					groups: {
+						path = '',
+					}
+				}
+			}
+		}) => {
+			return Response.redirect(new URL(`/${path}`, req.url));
+		}
 	},
 	staticPaths: ['/'],
 	port: 8000,
 	open: true,
+	requestPreprocessors: [
+		(req) => {
+			visits.emplace(req.url, {
+				insert() {
+					return 1;
+				},
+				update(oldValue) {
+					return oldValue + 1;
+				}
+			});
+
+			console.log(`${req.url} visit count: ${visits.get(req.url)}`);
+		},
+		useRateLimit({ timeout: 60_000, maxRequests: 100 }),
+		useRequestId,
+		checkCacheItem,
+		(req, { searchParams, controller }) => {
+			if (searchParams.has('secure') && ! req.headers.has('Authorization')) {
+				controller.abort(new HTTPError('I\'m sorry, Dave, I\'m afraid I can\'t do that.', { status: 401 }));
+			}
+		}
+	],
 	responsePostprocessors: [
+		useCompression('deflate'),
+		setCacheItem,
 		useCORS({ allowCredentials: true }),
 		useCSP({
 			'default-src': '\'none\'',
@@ -28,11 +68,5 @@ export default {
 			'media-src': '\'self\'',
 			'connect-src': ['\'self\'', 'http://localhost:*/'],
 		}),
-		setCacheItem,
-	],
-	requestPreprocessors: [
-		useRateLimit({ timeout: 60_000, maxRequests: 100 }),
-		useRequestId,
-		checkCacheItem,
 	],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shgysk8zer0/http-server",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@shgysk8zer0/http-server",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "funding": [
         {
           "type": "librepay",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shgysk8zer0/http-server",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A powerful but lightweight node server built using web standards",
   "keywords": [
     "server",

--- a/server.test.js
+++ b/server.test.js
@@ -1,22 +1,29 @@
 import { serve } from '@shgysk8zer0/http-server';
 import { test, describe } from 'node:test';
 import { deepStrictEqual, ok, strictEqual, fail } from 'node:assert';
+import { checkCacheItem, setCacheItem } from '@shgysk8zer0/http-server/cache.js';
+import net from 'node:net';
 
-const timeout = AbortSignal.timeout(60_000);
+const timeout = AbortSignal.timeout(10_000);
+const controller = new AbortController();
+const signal = AbortSignal.any([timeout, controller.signal]);
 
-describe('Test HTTP server', { concurrency: 5, signal: timeout }, async () => {
+describe('Test HTTP server', { concurrency: true, signal }, async () => {
 	let port = 8000;
 	const staticRoot = '/static/';
-	const controller = new AbortController();
 	const routes = {
-		'/tasks': '@shgysk8zer0/http-server/api/tasks.js',
 		'/': '@shgysk8zer0/http-server/api/home.js',
+		'/tasks': '@shgysk8zer0/http-server/api/tasks.js',
+		'/echo': '@shgysk8zer0/http-server/api/echo.js',
+		'/error': () => Response.error(),
+		'/text': req => req.text().then(text => new Response(text, { headers: { 'Content-Type': 'text/plain' }})),
 	};
 
-	test('Test basic, static requests', { signal: timeout }, async () => {
-		try {
-			const signal = AbortSignal.any([timeout, controller.signal]);
+	const requestPreprocessors = [checkCacheItem];
+	const responsePostprocessors = [setCacheItem];
 
+	test('Test basic, static requests', { signal }, async () => {
+		try {
 			const { url, server } = await serve({
 				port: port++,
 				signal,
@@ -24,6 +31,8 @@ describe('Test HTTP server', { concurrency: 5, signal: timeout }, async () => {
 				logger: fail,
 				routes,
 			});
+
+			ok(server.listening, 'Server should start correctly.');
 
 			const resp = await fetch(url, { signal });
 
@@ -36,9 +45,32 @@ describe('Test HTTP server', { concurrency: 5, signal: timeout }, async () => {
 		}
 	});
 
-	test('Test 404 responses', { signal: timeout }, async () => {
-		const signal = AbortSignal.any([timeout, controller.signal]);
+	test('Ensure that server shuts down correctly.', { signal }, async () => {
+		try {
+			const { server } = await serve({ signal });
 
+			server.close();
+			ok(! server.listening, 'Server should close correctly.');
+		} catch(err) {
+			controller.abort(err);
+			fail(err);
+		}
+	});
+
+	test('Ensure that server shuts down on signal abort.', { signal }, async () => {
+		try {
+			const controller = new AbortController();
+			const { server } = await serve({ signal: AbortSignal.any([signal, controller.signal]) });
+
+			controller.abort('Shut down!');
+			ok(! server.listening, 'Server should close correctly on signal abort.');
+		} catch(err) {
+			controller.abort(err);
+			fail(err);
+		}
+	});
+
+	test('Test 404 responses', { signal: timeout }, async () => {
 		try {
 			const { url, server } = await serve({
 				port: port++,
@@ -59,10 +91,29 @@ describe('Test HTTP server', { concurrency: 5, signal: timeout }, async () => {
 		}
 	});
 
+	test('Test 500 responses', { signal: timeout }, async () => {
+		try {
+			const { url, server } = await serve({
+				port: port++,
+				signal,
+				staticRoot,
+				logger: null, // Expected to error in 500
+				routes,
+			});
+
+			const resp = await fetch(new URL('./error', url), { signal });
+
+			ok(! resp.ok, 'Invalid URLs should not have an ok status code.');
+			strictEqual(resp.status, 500, 'Invalid URLs should have a status code of 500.');
+			server.close();
+		} catch(err) {
+			controller.abort(err);
+			fail(err);
+		}
+	});
+
 	test('Test dynamic route.', { signal: timeout }, async () => {
 		try {
-			const signal = AbortSignal.any([timeout, controller.signal]);
-
 			const { url, server } = await serve({
 				port: port++,
 				signal,
@@ -91,8 +142,6 @@ describe('Test HTTP server', { concurrency: 5, signal: timeout }, async () => {
 
 	test('Check pre/post processors.', { signal: timeout }, async () => {
 		try {
-			const signal = AbortSignal.any([timeout, controller.signal]);
-
 			const { url, server } = await serve({
 				port: port++,
 				signal,
@@ -128,7 +177,7 @@ describe('Test HTTP server', { concurrency: 5, signal: timeout }, async () => {
 		try {
 			const { url, server } = await serve({
 				port: port++,
-				signal: controller.signal,
+				signal,
 				staticRoot,
 				logger: null,
 				routes,
@@ -142,6 +191,233 @@ describe('Test HTTP server', { concurrency: 5, signal: timeout }, async () => {
 			const resp = await fetch(url, { signal: controller.signal });
 			strictEqual(resp.status, 408, 'Aborted requests should have a 4xx status code.');
 			strictEqual(resp.headers.get('Content-Type'), 'application/json', 'Aborted requests should should respond with an error as JSON.');
+			server.close();
+		} catch(err) {
+			controller.abort(err);
+			fail(err);
+		}
+	});
+
+	test('Check that it handles multiple concurrent requests.', { signal: timeout }, async () => {
+		try {
+			const reqCount = 100;
+
+			const { url, server } = await serve({
+				port: port++,
+				signal,
+				staticRoot,
+				logger: fail,
+				routes,
+				requestPreprocessors,
+				responsePostprocessors,
+			});
+
+			const reqs = Array(reqCount).fill(null).map(() => new Request(url));
+			const resps = await Promise.all(reqs.map(req => fetch(req)));
+
+			ok(resps.every(resp => resp.ok), 'Concurrent requests should be handled without error and have a status of 2xx.');
+			server.close();
+		} catch(err) {
+			controller.abort(err);
+			fail(err);
+		}
+	});
+
+	test('Test slow request.', { signal }, async () => {
+		try {
+			const { url, server } = await serve({
+				pathname: '/echo',
+				port: port++,
+				signal,
+				staticRoot,
+				logger: null,
+				routes,
+				requestPreprocessors,
+				responsePostprocessors,
+				timeout: 10,
+			});
+
+			const body = new ReadableStream({
+				async start(controller) {
+					const bytes = new TextEncoder().encode('Testing request timeout...');
+
+					for (let n = 0; n < bytes.length; n++) {
+						const chunk = await new Promise(resolve => setTimeout(() => resolve(bytes.subarray(n, n + 1)), 100));
+						controller.enqueue(chunk);
+					}
+
+					controller.close();
+				}
+			});
+
+			const resp = await fetch(url, {
+				headers: { 'Content-Type': 'text/plain' },
+				method: 'POST',
+				duplex: 'half',
+				body,
+				signal,
+			}).catch(() => Response.error());
+
+			strictEqual(resp.status, 408, 'Connection should timeout.');
+			server.close();
+		} catch(err) {
+			controller.abort(err);
+			fail(err);
+		}
+	});
+
+	test('Check requests with large payloads', { signal }, async () => {
+		try {
+			const blob = new Blob([Uint8Array.from({ length: 1024 * 1024})], { type: 'application/octet-stream'});
+			const { url, server } = await serve({
+				pathname: '/echo',
+				port: port++,
+				signal,
+				staticRoot,
+				logger: null,
+				routes,
+				requestPreprocessors,
+				responsePostprocessors,
+				timeout: 3_000,
+			});
+
+			const resp = await fetch(url, {
+				method: 'POST',
+				headers: { 'Content-Type': blob.type },
+				duplex: 'half',
+				body: blob.stream(),
+				signal,
+			});
+
+			ok(resp.ok, 'Large payloads should be handled correctly.');
+			server.close();
+		} catch(err) {
+			controller.abort(err);
+			fail(err);
+		}
+	});
+
+	test('Test Invalid HTTP Version', { signal }, async () => {
+		try {
+			const { url, server } = await serve({ port: port++, signal, logger: null, routes });
+			const reqURL = new URL(url);
+			// Directly using socket to send raw TCP data for version testing
+			let data = '';
+
+			const client = net.connect({ port: reqURL.port, host: reqURL.hostname }, () => {
+				client.write(`GET / HTTP/1.000\r\nHost: ${reqURL.host}\r\n\r\n`);
+			});
+
+
+			for await (const chunk of client) {
+				data += chunk.toString();
+				break; // Only need the first chunk with headers
+			}
+			client.destroy();
+			ok(data.startsWith('HTTP/1.1 400'), 'Should respond with 400 for invalid HTTP version.');
+			server.close();
+		} catch(err) {
+			controller.abort(err);
+			fail(err);
+		}
+	});
+
+	test('Test requests with invalid methods.', { signal }, async () => {
+		try {
+			const { url, server } = await serve({ port: port++, signal, logger: null, routes });
+			const resp = await fetch(url, { method: 'DNE' }).catch(() => Response.error());
+			ok(! resp.ok, 'Invalid request methods should error.');
+			server.close();
+		} catch(err) {
+			controller.abort(err);
+			fail(err);
+		}
+	});
+
+	test('Test Missing Host Header', { signal }, async () => {
+		try {
+			const { url, server } = await serve({ port: port++, signal, routes, logger: null });
+			const reqURL = new URL(url);
+			let data = '';
+
+			const client = net.connect({ port: reqURL.port, host: reqURL.hostname }, () => {
+				client.write('GET / HTTP/1.1\r\n\r\n'); // No Host header included
+			});
+
+			for await (const chunk of client) {
+				data += chunk.toString();
+				break; // Only need the first chunk with headers
+			}
+
+			client.destroy();
+			ok(data.startsWith('HTTP/1.1 400'), 'Should respond with 400 for missing Host header.');
+			server.close();
+		} catch (err) {
+			controller.abort(err);
+			fail(err);
+		}
+	});
+
+	test('Test Invalid Chars in HTTP', { signal }, async () => {
+		try {
+			const { url, server } = await serve({ port: port++, signal, routes, logger: null });
+			const reqURL = new URL(url);
+			let data = '';
+
+			const client = net.connect({ port: reqURL.port, host: reqURL.hostname }, () => {
+				client.write('GET abc!<@#$%^&*()"\' HTTP/1.1\r\nHost: ${reqURL.host}\r\n\r\n'); // Invalid chars in URL
+			});
+
+			for await (const chunk of client) {
+				data += chunk.toString();
+				break;
+			}
+
+			client.destroy();
+			ok(data.startsWith('HTTP/1.1 400'), 'Should respond with 400 for invalid URL.');
+			server.close();
+		} catch (err) {
+			controller.abort(err);
+			fail(err);
+		}
+	});
+
+	test('Test Invalid Newlines in HTTP', { signal }, async () => {
+		try {
+			const { url, server } = await serve({ port: port++, signal, routes, logger: null });
+			const reqURL = new URL(url);
+			let data = '';
+
+			const client = net.connect({ port: reqURL.port, host: reqURL.hostname }, () => {
+				client.write('GET / HTTP/1.1\nHost: ${reqURL.host}\r\n\r\n'); // Invalid newline
+			});
+
+			for await (const chunk of client) {
+				data += chunk.toString();
+				break;
+			}
+
+			client.destroy();
+			ok(data.startsWith('HTTP/1.1 400'), 'Should respond with 400 for invalid newline.');
+			server.close();
+		} catch (err) {
+			controller.abort(err);
+			fail(err);
+		}
+	});
+
+	test('Test Handling of Compressed Requests.', { signal }, async () => {
+		try {
+			const { url, server } = await serve({ port: port++, signal, routes, pathname: '/text', logger: fail });
+			const body = new ReadableStream({
+				start(controller) {
+					controller.enqueue('Hello, World!');
+					controller.close();
+				}
+			}).pipeThrough(new TextEncoderStream()).pipeThrough(new CompressionStream('gzip'));
+
+			const resp = await fetch(url, { method: 'PUT', body, duplex: 'half', headers: { 'Content-Type': 'text/plain', 'Content-Encoding': 'gzip' }});
+			strictEqual(await resp.text(), 'Hello, World!', 'Compressed request bodies should be supported.');
 			server.close();
 		} catch(err) {
 			controller.abort(err);

--- a/utils.js
+++ b/utils.js
@@ -3,7 +3,9 @@ import { join } from 'node:path';
 import { existsSync } from 'node:fs';
 
 export function resolveModulePath(path) {
-	if (path[0] === '.' || path[0] === '/') {
+	if (path instanceof URL || path instanceof Function) {
+		return path;
+	} else if (path[0] === '.' || path[0] === '/') {
 		return `file://${process.cwd()}/${path.replaceAll(/(\.+\/)/g, '')}`;
 	} else {
 		return import.meta.resolve(path);


### PR DESCRIPTION
### Added
- Add `createHandler()` for easier handler authoring
- Add support for middleware transforming response bodies (via `TransformStream`)
- Add support for request timeout in server config
- Add support for `--open` for more platforms
- Add `searchParams` to `context` passed to handlers
- Add support for inline function support instead of only module imports in handling requests
- Significantly expands testing

### Fixed
- Pass `signal` into `HTTPResponse` body parser

# Description and issue

> Please add relevant sections (Added, removed, changed, fixed) to `CHANGELOG.md`

## List of significant changes made
-  
-  
